### PR TITLE
Update to 1.7.3

### DIFF
--- a/clink.nuspec
+++ b/clink.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>clink-maintained</id>
-    <version>1.6.10</version>
+    <version>1.7.3</version>
     <owners>Piotr Szczygieł</owners>
     <title>Clink (maintained)</title>
     <authors>Martin Ridgers, Christopher Antos</authors>

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 ﻿Install-ChocolateyPackage `
     -PackageName 'clink-maintained' `
-    -Url 'https://github.com/chrisant996/clink/releases/download/v1.6.10/clink.1.6.10.d5dce0_setup.exe' `
-    -Checksum '5347a59a53c4c1310e6c71d72a7a3cbbf1004f2ae9b82de90a29eda0ac36ad58' `
+    -Url 'https://github.com/chrisant996/clink/releases/download/v1.7.3/clink.1.7.3.f8fb96_setup.exe' `
+    -Checksum '67e7a6c39d48fdf302a3002e816b63e8507941a7252a886d68e07779dafc73f7' `
     -ChecksumType 'SHA256' `
     -FileType 'EXE' `
     -SilentArgs '/S'


### PR DESCRIPTION
Update to clink 1.7.3 
Release Notes Url: https://github.com/chrisant996/clink/releases/tag/v1.7.3
Installer Url: https://github.com/chrisant996/clink/releases/download/v1.7.3/clink.1.7.3.f8fb96_setup.exe
Installer SHA256: 67e7a6c39d48fdf302a3002e816b63e8507941a7252a886d68e07779dafc73f7
Release Date: 2024-10-16