### PR TITLE
Update to clink v1.7.7

### DIFF
--- a/clink.nuspec
+++ b/clink.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>clink-maintained</id>
-    <version>1.7.3</version>
+    <version>1.7.7</version>
     <owners>Piotr Szczygieł</owners>
     <title>Clink (maintained)</title>
     <authors>Martin Ridgers, Christopher Antos</authors>

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 ﻿Install-ChocolateyPackage `
     -PackageName 'clink-maintained' `
-    -Url 'https://github.com/chrisant996/clink/releases/download/v1.7.3/clink.1.7.3.f8fb96_setup.exe' `
-    -Checksum '67e7a6c39d48fdf302a3002e816b63e8507941a7252a886d68e07779dafc73f7' `
+    -Url 'https://github.com/chrisant996/clink/releases/download/v1.7.7/clink.1.7.7.521fa7_setup.exe' `
+    -Checksum 'ad35745fee134f26fee83d9b890141484f74c9506fca88c2f3fcbe029b2e7eb6' `
     -ChecksumType 'SHA256' `
     -FileType 'EXE' `
     -SilentArgs '/S'


### PR DESCRIPTION
Update to clink v1.7.7
Release Notes Url: https://github.com/chrisant996/clink/releases/tag/v1.7.7
Installer Url: https://github.com/chrisant996/clink/releases/download/v1.7.7/clink.1.7.7.521fa7_setup.exe
Installer SHA256: ad35745fee134f26fee83d9b890141484f74c9506fca88c2f3fcbe029b2e7eb6
Release Date: 2024-12-26