### PR TITLE
Update to clink v1.7.13

### DIFF
--- a/clink.nuspec
+++ b/clink.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>clink-maintained</id>
-    <version>1.7.7</version>
+    <version>1.7.13</version>
     <owners>Piotr Szczygieł</owners>
     <title>Clink (maintained)</title>
     <authors>Martin Ridgers, Christopher Antos</authors>

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 ﻿Install-ChocolateyPackage `
     -PackageName 'clink-maintained' `
-    -Url 'https://github.com/chrisant996/clink/releases/download/v1.7.7/clink.1.7.7.521fa7_setup.exe' `
-    -Checksum 'ad35745fee134f26fee83d9b890141484f74c9506fca88c2f3fcbe029b2e7eb6' `
+    -Url 'https://github.com/chrisant996/clink/releases/download/v1.7.13/clink.1.7.13.ac5d42_setup.exe' `
+    -Checksum '5057c7cf085337775dc8ca4cccfabef620dd9451d2d05d1287ee955cef12590d' `
     -ChecksumType 'SHA256' `
     -FileType 'EXE' `
     -SilentArgs '/S'


### PR DESCRIPTION
Upsteam changelog:
v1.7.13:
- Added an error message when `clink set` fails to write the `clink_settings` file (e.g. no permission or the file is marked read-only).
- Added logging when `clink inject` is slow.
- Added keyboard info in `clink echo --verbose`.
- Condensed the logging during `clink inject`, but if an error occurs while hooking system APIs then it automatically emits verbose logging instead of condensed logging.
- Fixed the maximum vertical scroll position limiter to include the input hint row when using the legacy Windows conhost.
- Fixed [#732](https://github.com/chrisant996/clink/issues/732); Executable Completion does not recognize `.LNK` files.

v1.7.12:
- Fixed what `io.popenyield()` returns upon failure; previously it accidentally only returned nil, and now upon failure it returns the usual values (nil, error message, error code).
- Fixed [#727](https://github.com/chrisant996/clink/issues/727); custom prompts can crash Clink when `cd` into a path that exceeds MAX_PATH length.

v1.7.11:
- Changed the `clink-diagnostics-output` bindable command to include a list of the current Clink settings.
- Changed logged error codes to include the corresponding message text for the error code.
- Fixed input hints in chained argmatchers (it could sometimes show a hint from the preceding word by mistake).
- Fixed height of scrollbars in popup lists and in the `select-complete` command (they were half as tall as they should have been).

v1.7.10:
- Added new Lua API [unicode.char()](#unicode.char), similar to [string.char()](https://www.lua.org/manual/5.2/manual.html#pdf-string.char) but for Unicode codepoints instead of ASCII values.
- Added a `clink-diagnostics-output` bindable command, bound by default to <kbd>Ctrl</kbd>-<kbd>X</kbd>,<kbd>Ctrl</kbd>-<kbd>Shift</kbd>-<kbd>Z</kbd>.  The command writes internal diagnostic information to a file which can be shared to simplify troubleshooting.  This command also includes a list of all loaded Lua scripts.
- Fixed [#721](https://github.com/chrisant996/clink/issues/721); potential crash if console window width is less than console screen buffer width (regression introduced in v1.7.5).

v1.7.9:
- Fixed [#719](https://github.com/chrisant996/clink/issues/719); async prompt filtering can stall for 15 seconds (regression introduced in v1.7.8).

v1.7.8:
- Added <kbd>Ctrl</kbd>-<kbd>C</kbd> binding in vi keymaps, to match normal Readline behavior ([#716](https://github.com/chrisant996/clink/discussions/716)).
- Fixed missing auto-suggestions when anchored to the end of the input line (regression introduced in v1.6.4).\r\n- Fixed [#718](https://github.com/chrisant996/clink/issues/718); potential for "coroutine is orphaned" error, depending on the CPU speed and how `autosuggest.strategy` is configured (regression introduced in v1.3.26).