### PR TITLE
Update to clink v1.7.14

### DIFF
--- a/clink.nuspec
+++ b/clink.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>clink-maintained</id>
-    <version>1.7.13</version>
+    <version>1.7.14</version>
     <owners>Piotr Szczygieł</owners>
     <title>Clink (maintained)</title>
     <authors>Martin Ridgers, Christopher Antos</authors>

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -1,6 +1,6 @@
 ﻿Install-ChocolateyPackage `
     -PackageName 'clink-maintained' `
-    -Url 'https://github.com/chrisant996/clink/releases/download/v1.7.13/clink.1.7.13.ac5d42_setup.exe' `
+    -Url 'https://github.com/chrisant996/clink/releases/download/v1.7.14/clink.1.7.14.843933_setup.exe' `
     -Checksum '5057c7cf085337775dc8ca4cccfabef620dd9451d2d05d1287ee955cef12590d' `
     -ChecksumType 'SHA256' `
     -FileType 'EXE' `


### PR DESCRIPTION
Upstream changelog:
- Added a new `clink.scroll_offset` setting which controls how many lines to show above or below the selected item in popup lists or the `clink-select-complete` command (default is 3).
- Changed <code>clink set <span class="arg">name</span></code> to include the default value of the named setting.
- The Antares clinkprompt now allows configuring the characters for showing the previous command's exit code (refer to the Antares.clinkprompt file for details).
- The `clink-diagnostics` and `clink-diagnostics-output` bindable commands also show the current *.clinkprompt custom prompt file, if any.
- Fixed a problem where <kbd>Esc</kbd> could leak or corrupt history undo lists when used after searching history (the problem existed since v0.1 in 2012).
- Fixed the `clink-show-help` command to stop listing the `A-f` default key binding as an "Uncategorized" command.
- Fixed a typo in the Antares clinkprompt when trying to detect a bare git repo.
- Fixed the `history.sticky_search` setting (regression introduced in v1.5.12).
- Fixed default color for `color.selected_completion` to have better contrast ratio in light terminal themes.
- Fixed input edge cases in the `win-history-list` command which missed updating the display.
- Fixed a color glitch in the `clink-popup-history` command for history lines marked as having been modified in memory.
- Fixed the `win-history-list` command to show a mark for history lines that have been modified in memory, like the `clink-popup-history` command already does.
- Fixed an issue where instead of always starting on a new line, output from a command could potentially accidentally start at the end of the input line.
- Fixed some memory management bugs in history item undo lists.
- Added a workaround to fix [#738](https://github.com/chrisant996/clink/issues/738); Windows Terminal does not handle the `CSI K` code correctly when the cursor is past the end of the screen line.
- Improvements for [#739](https://github.com/chrisant996/clink/issues/739); ConsoleZ, ConEmu, and other tools can interfere with injecting Clink (there's no way to completely prevent opportunities for interference, but this reduces the chances).