### PR TITLE
Update to clink v1.7.16

### DIFF
--- a/clink.nuspec
+++ b/clink.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>clink-maintained</id>
-    <version>1.7.14</version>
+    <version>1.7.16</version>
     <owners>Piotr Szczygieł</owners>
     <title>Clink (maintained)</title>
     <authors>Martin Ridgers, Christopher Antos</authors>

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -1,6 +1,6 @@
 ﻿Install-ChocolateyPackage `
     -PackageName 'clink-maintained' `
-    -Url 'https://github.com/chrisant996/clink/releases/download/v1.7.14/clink.1.7.14.843933_setup.exe' `
+    -Url 'https://github.com/chrisant996/clink/releases/download/v1.7.16/clink.1.7.16.988e1c_setup.exe' `
     -Checksum '5057c7cf085337775dc8ca4cccfabef620dd9451d2d05d1287ee955cef12590d' `
     -ChecksumType 'SHA256' `
     -FileType 'EXE' `


### PR DESCRIPTION
Upstream changelog:

v1.7.16:
- Fixed potential crash after pressing <kbd>Home</kbd> and then deleting the first word in the input line (regression introduced in v1.7.15).

v1.7.15:
- Fixed the sequence of characters `clink echo` reports for <kbd>Ctrl</kbd>-<kbd>Bkspc</kbd>.
- Fixed an issue where the `match.expand_abbrev` setting could accidentally move the cursor position when trying to complete `x:\does_not_exist`.
- Fixed input line coloring to refresh the display if `clink.argmatcher()` registers a new argmatcher in response to an event such as `clink.oncommand`.
- Fixed extra prompt(s) that could printed if a `luafunc:` command used `rl_buffer:beginoutput()` and then `rl.invokecommand()` to invoke another `luafunc:` command that did the same, nesting multiple times.
- Fixed negative numeric arguments with `rl_buffer:getargument()` and `rl_buffer:setargument()`.
- Fixed potential heap corruption in `os.enumshares()`.
- Fixed both completions and `clink.parseline()` when a command is a doskey alias but ends up with only a command name and spaces after expanding the alias (completions got confused about which argument slot was being completed, and `clink.parseline()` accidentally reported an extra empty word at the end of the input line).
- Fixed [#743](https://github.com/chrisant996/clink/issues/743); output doesn't scroll terminal correctly when the terminal screen buffer width is wider than the terminal window width (regression introduced in v1.6.2).
- Fixed [#744](https://github.com/chrisant996/clink/issues/744); `git.getaction()` prevents git from properly cleaning up rebase files if you edit a commit during a rebase.
- Fixed [#745](https://github.com/chrisant996/clink/issues/745); out of bounds read in memcpy after typing `cmd /;=` and then moving the cursor left twice (regression introduced in v1.5.17).
