### PR TITLE
Update to clink v1.7.18

### DIFF
--- a/clink.nuspec
+++ b/clink.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>clink-maintained</id>
-    <version>1.7.16</version>
+    <version>1.7.18</version>
     <owners>Piotr Szczygieł</owners>
     <title>Clink (maintained)</title>
     <authors>Martin Ridgers, Christopher Antos</authors>

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -1,6 +1,6 @@
 ﻿Install-ChocolateyPackage `
     -PackageName 'clink-maintained' `
-    -Url 'https://github.com/chrisant996/clink/releases/download/v1.7.16/clink.1.7.16.988e1c_setup.exe' `
+    -Url 'https://github.com/chrisant996/clink/releases/download/v1.7.18/clink.1.7.18.5581bd_setup.exe' `
     -Checksum '5057c7cf085337775dc8ca4cccfabef620dd9451d2d05d1287ee955cef12590d' `
     -ChecksumType 'SHA256' `
     -FileType 'EXE' `

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 ﻿Install-ChocolateyPackage `
     -PackageName 'clink-maintained' `
     -Url 'https://github.com/chrisant996/clink/releases/download/v1.7.18/clink.1.7.18.5581bd_setup.exe' `
-    -Checksum '5057c7cf085337775dc8ca4cccfabef620dd9451d2d05d1287ee955cef12590d' `
+    -Checksum 'fb32589d41aadd761269536a062ce0fde6e52511368abaa6c17e624d55833949' `
     -ChecksumType 'SHA256' `
     -FileType 'EXE' `
     -SilentArgs '/S'


### PR DESCRIPTION
Upstream changelog:
### v1.7.18

- Fixed [#752](https://github.com/chrisant996/clink/issues/752); `clink config theme use {name}` reports an error (regression introduced in v1.7.17).

### v1.7.17

- Added "4-bit Enhanced Defaults.clinktheme" color theme which approximates the "Enhanced Defaults" colors using only 4-bit terminal colors.
- Added a `clink config theme save -d` flag to save a color theme with placeholders for color settings whose current value matches its default value.  Loading a color theme saved this way resets those colors to whatever default values are defined at the moment the file is loaded.
- Changed the default behavior for throttling Lua coroutines.  By default there is no throttling anymore.  The new `lua.throttle_interval` setting can be used to enable throttling of Lua coroutines if they cause responsiveness issues.  Prior to this, the throttling interval had been hard-coded to 5 seconds, but now it's configurable and is 0 by default (no throttling).
- Changed `rl.getpromptinfo()` to be allowed during transient prompt filtering (but still not during normal prompt filtering).
- Added an optimization to replay keyboard macros faster.
- Added an optimization to read key sequences faster, which makes Clink a little more responsive while typing.
- Fixed erasing leftover input text if the prompt height changes while typing.
- Fixed the `oncommand` event when an argmatcher uses `:chaincommand()`.
- Fixed the `line_state` sent to `luafunc:` macros invoked during a keyboard macro (it was empty if the keyboard macro had changed the input line).
- Fixed use of `clink.promptcoroutine()` during transient prompt filtering (it was accidentally trying to do asynchronous prompt filtering, which isn't possible during transient prompt filtering).
- Fixed the `onadvance` callback in argmatchers so it doesn't interfere with match generation.
- Fixed a problem where `clink-popup-history` could leak or lose the undo list from the current input line.
- Fixed an error when applying a `*.clinktheme` file with a `[clear]` section.
- Fixed [#751](https://github.com/chrisant996/clink/issues/751); multi-line oh-my-posh config without newlines causes display problem.