### PR TITLE
Update to clink v1.7.19

### DIFF
--- a/clink.nuspec
+++ b/clink.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>clink-maintained</id>
-    <version>1.7.18</version>
+    <version>1.7.19</version>
     <owners>Piotr Szczygieł</owners>
     <title>Clink (maintained)</title>
     <authors>Martin Ridgers, Christopher Antos</authors>

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 ﻿Install-ChocolateyPackage `
     -PackageName 'clink-maintained' `
-    -Url 'https://github.com/chrisant996/clink/releases/download/v1.7.18/clink.1.7.18.5581bd_setup.exe' `
-    -Checksum 'fb32589d41aadd761269536a062ce0fde6e52511368abaa6c17e624d55833949' `
+    -Url 'https://github.com/chrisant996/clink/releases/download/v1.7.19/clink.1.7.19.d8a218_setup.exe' `
+    -Checksum '09c62c9085e8cfec420b3459c526433bdea70c436568ab2681257995ab0089db' `
     -ChecksumType 'SHA256' `
     -FileType 'EXE' `
     -SilentArgs '/S'


### PR DESCRIPTION
Upstream changelog:
- Fixed some unnecessary work that was performed when starting the Lua engine (a tiny performance boost).
- Fixed `os.getcwd()` when the [LongPathsEnabled](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry#registry-setting-to-enable-long-paths) regkey is set.
- Fixed the application manifest for the `clink_*.exe` programs to mark them as longPathAware (this doesn't affect CMD; while Clink is injected in CMD, then CMD's manifest is what controls long path awareness).
- Fixed the `oncommand` event when using `clink-popup-history` to select and execute a command from history.
- Fixed [#756](https://github.com/chrisant996/clink/issues/756); Clink could potentially think it wasn't elevated when running as `LOCAL_SYSTEM` or the builtin `Administrator` account.
- Fixed [#758](https://github.com/chrisant996/clink/issues/758); avoid crashing in a pathological case where something else abuses CMD by injecting background threads that actively garble input and output.
- Fixed the `info` command in the Lua debugger.