### PR TITLE
Update to clink v1.7.20

### DIFF
--- a/clink.nuspec
+++ b/clink.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>clink-maintained</id>
-    <version>1.7.19</version>
+    <version>1.7.20</version>
     <owners>Piotr Szczygieł</owners>
     <title>Clink (maintained)</title>
     <authors>Martin Ridgers, Christopher Antos</authors>

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 ﻿Install-ChocolateyPackage `
     -PackageName 'clink-maintained' `
-    -Url 'https://github.com/chrisant996/clink/releases/download/v1.7.19/clink.1.7.19.d8a218_setup.exe' `
-    -Checksum '09c62c9085e8cfec420b3459c526433bdea70c436568ab2681257995ab0089db' `
+    -Url 'https://github.com/chrisant996/clink/releases/download/v1.7.20/clink.1.7.20.9f8e98_setup.exe' `
+    -Checksum '9cfc3c6a4883c0a6570ccc51827709edac1cc5f5559fae3d64d7f3e73743eaea' `
     -ChecksumType 'SHA256' `
     -FileType 'EXE' `
     -SilentArgs '/S'


### PR DESCRIPTION
Upstream changelog:
- Fixed [#763](https://github.com/chrisant996/clink/issues/763); transient prompt has blank line after it if the input line is the width of the terminal (regression introduced in v1.7.0).
- Fixed [#765](https://github.com/chrisant996/clink/issues/765); inside a batch script, `setlocal` interferes with injecting Clink (regression introduced in v1.1.1).