### PR TITLE
Update to clink v1.7.21

### DIFF
--- a/clink.nuspec
+++ b/clink.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>clink-maintained</id>
-    <version>1.7.20</version>
+    <version>1.7.21</version>
     <owners>Piotr Szczygieł</owners>
     <title>Clink (maintained)</title>
     <authors>Martin Ridgers, Christopher Antos</authors>

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 ﻿Install-ChocolateyPackage `
     -PackageName 'clink-maintained' `
-    -Url 'https://github.com/chrisant996/clink/releases/download/v1.7.20/clink.1.7.20.9f8e98_setup.exe' `
-    -Checksum '9cfc3c6a4883c0a6570ccc51827709edac1cc5f5559fae3d64d7f3e73743eaea' `
+    -Url 'https://github.com/chrisant996/clink/releases/download/v1.7.21/clink.1.7.21.9f5af8_setup.exe' `
+    -Checksum '432ae8e3818de8a121d38c5b2b815d04cd15784482ac3d55245a0ff30814d5cc' `
     -ChecksumType 'SHA256' `
     -FileType 'EXE' `
     -SilentArgs '/S'


### PR DESCRIPTION
Upstream changelog:
- Fixed TAB expansion of `foo ~` when there is no argmatcher for `foo`.
- Fixed [#772](https://github.com/chrisant996/clink/issues/772); uninstall fails to uninstall autorun if the logged on user is not an administrator.
- Fixed [#773](https://github.com/chrisant996/clink/issues/773); unexpected completion behavior after a doskey alias command.