### PR TITLE
Update to clink v1.7.22

### DIFF
--- a/clink.nuspec
+++ b/clink.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>clink-maintained</id>
-    <version>1.7.21</version>
+    <version>1.7.22</version>
     <owners>Piotr Szczygieł</owners>
     <title>Clink (maintained)</title>
     <authors>Martin Ridgers, Christopher Antos</authors>

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 ﻿Install-ChocolateyPackage `
     -PackageName 'clink-maintained' `
-    -Url 'https://github.com/chrisant996/clink/releases/download/v1.7.21/clink.1.7.21.9f5af8_setup.exe' `
-    -Checksum '432ae8e3818de8a121d38c5b2b815d04cd15784482ac3d55245a0ff30814d5cc' `
+    -Url 'https://github.com/chrisant996/clink/releases/download/v1.7.22/clink.1.7.22.38f1a3_setup.exe' `
+    -Checksum '985dbea93b890a67739f5538b1f5eefeb79eb72612190c6798a8b91c2499e1cd' `
     -ChecksumType 'SHA256' `
     -FileType 'EXE' `
     -SilentArgs '/S'


### PR DESCRIPTION
Upstream changelog:
- Explicitly disable `loadlib` and related support in Lua; Clink uses a statically linked Lua engine and does not support dynamic C libraries.
- Fixed the `onprovideline` event so it doesn't interfere with the `same_dir` mode of `prompt.transient`.
- Fixed input line coloring of `echo` in `for %i (1 2 3) do @echo %i` (regression introduced in v1.6.16).
- Fixed how `clink autorun set` parses flags and quotes, so that `clink autorun set \"c:\my tools\clink\" inject --autorun` works as expected.
- Fixed the `exec.commands` setting when an argmatcher uses `:chaincommand()`.
- Fixed edge cases for `@` command prefix when an argmatcher uses `:chaincommand()`.
- Fixed [#779](https://github.com/chrisant996/clink/issues/779); an argmatcher's `onadvance` callback accidentally advanced two times if it advanced to the last argument slot.
- Fixed [#782](https://github.com/chrisant996/clink/issues/782); on Windows 8.1, some multiline prompts may render with extra blank lines.